### PR TITLE
Accept android sdk 28 licenses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "build.gradle" }}
       - run:
           name: Download Dependencies
+          command: yes | sdkmanager --licenses
           command: ./gradlew androidDependencies
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,9 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "build.gradle" }}
       - run:
           name: Download Dependencies
-          command: yes | sdkmanager --licenses
-          command: ./gradlew androidDependencies
+          command:
+            yes | sdkmanager --licenses
+            ./gradlew androidDependencies
       - save_cache:
           paths:
             - ~/.gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,11 @@ jobs:
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "build.gradle" }}
       - run:
+          name: Accept license
+          command: yes | sdkmanager --licenses
+      - run:
           name: Download Dependencies
-          command:
-            yes | sdkmanager --licenses
-            ./gradlew androidDependencies
+          command: ./gradlew androidDependencies
       - save_cache:
           paths:
             - ~/.gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "build.gradle" }}
       - run:
           name: Accept license
-          command: yes | sdkmanager --licenses
+          command: yes | sdkmanager --licenses || true
       - run:
           name: Download Dependencies
           command: ./gradlew androidDependencies


### PR DESCRIPTION
### Background:
The circleci image uses sdk version 25, so we have to explicitly accept the license

### Change:
change circle.yml to accept new licenses

## Tests:
circleci in PR